### PR TITLE
v3 update for including costed BOM breakdown in component data output and HTML view

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -212,34 +212,35 @@ def extract_data_from_digikey_search_response(keyword_search_json):
 ################################################################################
 def get_prices_for_target_qty(part_data, qty):
     prices = []
-    # Iterate through list of pricing data
-    for pricing_type in part_data.pricing:
-        # Get the standard pricing for this package type
-        std_pricing = pricing_type["StandardPricing"]
-        # Initialize a pricing dictionary and populate package type
-        price_dict = {}
-        price_dict["package_type"] = pricing_type["PackageType"]
-        # Get price breakpoints for this pricing type
-        breakpoints = [int(stdpricing["BreakQuantity"]) for stdpricing in std_pricing]
-        # Set the breakpoint index to start or end of list, or as None,
-        # depending on the quantity. Set pricing for edge case
-        breakpoint_idx = (
-            0 if qty <= min(breakpoints) else -1 if qty >= max(breakpoints) else None
-        )
-        if breakpoint_idx is not None:
-            price_dict["break_qty"] = std_pricing[breakpoint_idx]["BreakQuantity"]
-            price_dict["price_per_unit"] = std_pricing[breakpoint_idx]["UnitPrice"]
-            price_dict["total_price"] = std_pricing[breakpoint_idx]["UnitPrice"] * qty
-        else:
-            # Populate break quantity and prices the target quantity
-            for breakpoint in std_pricing:
-                # If breakpoint index already set, populate
-                if qty > breakpoint["BreakQuantity"]:
-                    price_dict["break_qty"] = breakpoint["BreakQuantity"]
-                    price_dict["price_per_unit"] = breakpoint["UnitPrice"]
-                    price_dict["total_price"] = breakpoint["UnitPrice"] * qty
-        # Add pricing dict to the list of pricing types
-        prices.append(price_dict)
+    # Iterate through list of pricing data if pricing data exists
+    if part_data.pricing:
+        for pricing_type in part_data.pricing:
+            # Get the standard pricing for this package type
+            std_pricing = pricing_type["StandardPricing"]
+            # Initialize a pricing dictionary and populate package type
+            price_dict = {}
+            price_dict["package_type"] = pricing_type["PackageType"]
+            # Get price breakpoints for this pricing type
+            breakpoints = [int(stdpricing["BreakQuantity"]) for stdpricing in std_pricing]
+            # Set the breakpoint index to start or end of list, or as None,
+            # depending on the quantity. Set pricing for edge case
+            breakpoint_idx = (
+                0 if qty <= min(breakpoints) else -1 if qty >= max(breakpoints) else None
+            )
+            if breakpoint_idx is not None:
+                price_dict["break_qty"] = std_pricing[breakpoint_idx]["BreakQuantity"]
+                price_dict["price_per_unit"] = std_pricing[breakpoint_idx]["UnitPrice"]
+                price_dict["total_price"] = std_pricing[breakpoint_idx]["UnitPrice"] * qty
+            else:
+                # Populate break quantity and prices the target quantity
+                for breakpoint in std_pricing:
+                    # If breakpoint index already set, populate
+                    if qty > breakpoint["BreakQuantity"]:
+                        price_dict["break_qty"] = breakpoint["BreakQuantity"]
+                        price_dict["price_per_unit"] = breakpoint["UnitPrice"]
+                        price_dict["total_price"] = breakpoint["UnitPrice"] * qty
+            # Add pricing dict to the list of pricing types
+            prices.append(price_dict)
     # Return the populated pricing data
     return prices
 
@@ -313,7 +314,7 @@ if __name__ == "__main__":
 
     # Fetch information for all parts in the BOM
     for line_item in bom_line_items:
-        print("- Fetching info for " + line_item[0])
+        print("- Fetching info for " + line_item[0] + "... ", end="")
         # Search for parts in DigiKey by Manufacturer Part Number as keyword
         (response_code, keyword_search_json) = query_digikey_v4_API_keyword_search(
             DIGIKEY_API_V4_KEYWORD_SEARCH_ENDPOINT,
@@ -325,6 +326,7 @@ if __name__ == "__main__":
             "0",
             line_item[0],
         )
+        print("✔" + "\n", end="", flush=True)
         # Process a successful response
         if response_code == 200:
             # Extract the part data from the keyword search response

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -217,30 +217,32 @@ def get_prices_for_target_qty(part_data, qty):
         for pricing_type in part_data.pricing:
             # Get the standard pricing for this package type
             std_pricing = pricing_type["StandardPricing"]
-            # Initialize a pricing dictionary and populate package type
-            price_dict = {}
-            price_dict["package_type"] = pricing_type["PackageType"]
-            # Get price breakpoints for this pricing type
-            breakpoints = [int(stdpricing["BreakQuantity"]) for stdpricing in std_pricing]
-            # Set the breakpoint index to start or end of list, or as None,
-            # depending on the quantity. Set pricing for edge case
-            breakpoint_idx = (
-                0 if qty <= min(breakpoints) else -1 if qty >= max(breakpoints) else None
-            )
-            if breakpoint_idx is not None:
-                price_dict["break_qty"] = std_pricing[breakpoint_idx]["BreakQuantity"]
-                price_dict["price_per_unit"] = std_pricing[breakpoint_idx]["UnitPrice"]
-                price_dict["total_price"] = std_pricing[breakpoint_idx]["UnitPrice"] * qty
-            else:
-                # Populate break quantity and prices the target quantity
-                for breakpoint in std_pricing:
-                    # If breakpoint index already set, populate
-                    if qty > breakpoint["BreakQuantity"]:
-                        price_dict["break_qty"] = breakpoint["BreakQuantity"]
-                        price_dict["price_per_unit"] = breakpoint["UnitPrice"]
-                        price_dict["total_price"] = breakpoint["UnitPrice"] * qty
-            # Add pricing dict to the list of pricing types
-            prices.append(price_dict)
+            # Process the pricing type if data exists, else skip
+            if std_pricing:
+                # Initialize a pricing dictionary and populate package type
+                price_dict = {}
+                price_dict["package_type"] = pricing_type["PackageType"]
+                # Get price breakpoints for this pricing type
+                breakpoints = [int(stdpricing["BreakQuantity"]) for stdpricing in std_pricing]
+                # Set the breakpoint index to start or end of list, or as None,
+                # depending on the quantity. Set pricing for edge case
+                breakpoint_idx = (
+                    0 if qty <= min(breakpoints) else -1 if qty >= max(breakpoints) else None
+                )
+                if breakpoint_idx is not None:
+                    price_dict["break_qty"] = std_pricing[breakpoint_idx]["BreakQuantity"]
+                    price_dict["price_per_unit"] = std_pricing[breakpoint_idx]["UnitPrice"]
+                    price_dict["total_price"] = std_pricing[breakpoint_idx]["UnitPrice"] * qty
+                else:
+                    # Populate break quantity and prices the target quantity
+                    for breakpoint in std_pricing:
+                        # If breakpoint index already set, populate
+                        if qty > breakpoint["BreakQuantity"]:
+                            price_dict["break_qty"] = breakpoint["BreakQuantity"]
+                            price_dict["price_per_unit"] = breakpoint["UnitPrice"]
+                            price_dict["total_price"] = breakpoint["UnitPrice"] * qty
+                # Add pricing dict to the list of pricing types
+                prices.append(price_dict)
     # Return the populated pricing data
     return prices
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -287,7 +287,7 @@ if __name__ == "__main__":
 
     # Get the PCB quantities, if specified
     quantities = []
-    if args.pcb_quanities:
+    if args.pcb_quantities:
         try:
             # Get the quantities as a list of integers
             quantities = [int(quantity) for quantity in args.pcb_quantities.split(",")]

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -332,7 +332,7 @@ if __name__ == "__main__":
             # Add the associated reference designators
             part_data.associated_refdes = line_item[refdes_col_idx]
             # Get the COGS pricing if PCB quantities specified
-            if args.pcb_quanities:
+            if args.pcb_quantities:
                 cogs_breakdown = {}
                 for quantity in quantities:
                     cogs_breakdown[str(quantity)] = get_prices_for_target_qty(

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -44,7 +44,7 @@ class ComponentData:
     eccn: str = None
     htsus: str = None
     categories: list = field(default_factory=list)
-    cogs_breakdown: dict = field(default_factory=dict)
+    cogs_breakdown: list = field(default_factory=list)
 
 
 ################################################################################
@@ -210,9 +210,10 @@ def extract_data_from_digikey_search_response(keyword_search_json):
 
 
 ################################################################################
-def get_prices_for_target_qty(part_data, qty):
-    prices = []
-    # Iterate through list of pricing data if pricing data exists
+def get_prices_for_target_qtys(part_data, single_pcb_part_qty, pcb_quantities):
+    # Initialize list of prices to populate and return
+    pcb_qty_prices_by_part_type = []
+    # Iterate through list of quantities and pricing data if pricing data exists
     if part_data.pricing:
         for pricing_type in part_data.pricing:
             # Get the standard pricing for this package type
@@ -220,31 +221,58 @@ def get_prices_for_target_qty(part_data, qty):
             # Process the pricing type if data exists, else skip
             if std_pricing:
                 # Initialize a pricing dictionary and populate package type
-                price_dict = {}
-                price_dict["package_type"] = pricing_type["PackageType"]
+                pricing_for_price_type = {}
+                pricing_for_price_type["package_type"] = pricing_type["PackageType"]
+                pricing_for_price_type["cogs"] = []
                 # Get price breakpoints for this pricing type
-                breakpoints = [int(stdpricing["BreakQuantity"]) for stdpricing in std_pricing]
-                # Set the breakpoint index to start or end of list, or as None,
-                # depending on the quantity. Set pricing for edge case
-                breakpoint_idx = (
-                    0 if qty <= min(breakpoints) else -1 if qty >= max(breakpoints) else None
-                )
-                if breakpoint_idx is not None:
-                    price_dict["break_qty"] = std_pricing[breakpoint_idx]["BreakQuantity"]
-                    price_dict["price_per_unit"] = std_pricing[breakpoint_idx]["UnitPrice"]
-                    price_dict["total_price"] = std_pricing[breakpoint_idx]["UnitPrice"] * qty
-                else:
-                    # Populate break quantity and prices the target quantity
-                    for breakpoint in std_pricing:
-                        # If breakpoint index already set, populate
-                        if qty > breakpoint["BreakQuantity"]:
-                            price_dict["break_qty"] = breakpoint["BreakQuantity"]
-                            price_dict["price_per_unit"] = breakpoint["UnitPrice"]
-                            price_dict["total_price"] = breakpoint["UnitPrice"] * qty
+                breakpoints = [
+                    int(stdpricing["BreakQuantity"]) for stdpricing in std_pricing
+                ]
+                # Iterate through the PCB quantities for COGS breakdown
+                for pcb_qty in pcb_quantities:
+                    # Initialize a dict for populating COGS for this PCB quantity
+                    pricing_for_pcb_qty = {}
+                    # Get the total part count for this PCB quantity
+                    part_qty = single_pcb_part_qty * pcb_qty
+                    # Set the breakpoint index to start or end of list, or as None,
+                    # depending on the quantity. Set pricing for edge case
+                    breakpoint_idx = (
+                        0
+                        if part_qty <= min(breakpoints)
+                        else -1
+                        if part_qty >= max(breakpoints)
+                        else None
+                    )
+                    if breakpoint_idx is not None:
+                        pricing_for_pcb_qty[str(pcb_qty)]["break_qty"] = std_pricing[
+                            breakpoint_idx
+                        ]["BreakQuantity"]
+                        pricing_for_pcb_qty[str(pcb_qty)]["price_per_unit"] = (
+                            std_pricing[breakpoint_idx]["UnitPrice"]
+                        )
+                        pricing_for_pcb_qty[str(pcb_qty)]["total_price"] = (
+                            std_pricing[breakpoint_idx]["UnitPrice"] * part_qty
+                        )
+                    else:
+                        # Populate break quantity and prices the target quantity
+                        for breakpoint in std_pricing:
+                            # If breakpoint index already set, populate
+                            if part_qty >= breakpoint["BreakQuantity"]:
+                                pricing_for_pcb_qty[str(pcb_qty)]["break_qty"] = (
+                                    breakpoint["BreakQuantity"]
+                                )
+                                pricing_for_pcb_qty[str(pcb_qty)]["price_per_unit"] = (
+                                    breakpoint["UnitPrice"]
+                                )
+                                pricing_for_pcb_qty[str(pcb_qty)]["total_price"] = (
+                                    breakpoint["UnitPrice"] * part_qty
+                                )
+                    # Append the pricing for this PCB quantity to the list
+                    pricing_for_price_type["cogs"].append(pricing_for_pcb_qty)
                 # Add pricing dict to the list of pricing types
-                prices.append(price_dict)
+                pcb_qty_prices_by_part_type.append(pricing_for_price_type)
     # Return the populated pricing data
-    return prices
+    return pcb_qty_prices_by_part_type
 
 
 ################################################################################
@@ -289,11 +317,13 @@ if __name__ == "__main__":
         del bom_line_items[0]
 
     # Get the PCB quantities, if specified
-    quantities = []
+    pcb_quantities = []
     if args.pcb_quantities:
         try:
             # Get the quantities as a list of integers
-            quantities = [int(quantity) for quantity in args.pcb_quantities.split(",")]
+            pcb_quantities = [
+                int(quantity) for quantity in args.pcb_quantities.split(",")
+            ]
         except Exception:
             pass
 
@@ -337,13 +367,15 @@ if __name__ == "__main__":
             part_data.associated_refdes = line_item[refdes_col_idx]
             # Get the COGS pricing if PCB quantities specified
             if args.pcb_quantities:
+                # Get the number of components needed for this part
+                part_qty = len(part_data.associated_refdes.split(","))
+                # Initialize a COGS breakdown dict for the different quantities
                 cogs_breakdown = {}
-                for quantity in quantities:
-                    cogs_breakdown[str(quantity)] = get_prices_for_target_qty(
-                        part_data, quantity
-                    )
-                # Add the COGS breakdown to component data
-                part_data.cogs_breakdown = cogs_breakdown
+                # Iterate PCB quantities and get prices for component quantities
+                # at each PCB quantity. Add COGS breakdown to the component data set
+                part_data.cogs_breakdown = get_prices_for_target_qtys(
+                    part_data, part_qty, pcb_quantities
+                )
             # Add the extracted data to the list of BOM items part data
             bom_items_digikey_data.append(part_data)
         # Print out the details of an unsuccessful response

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -231,8 +231,7 @@ def get_prices_for_target_qtys(part_data, single_pcb_part_qty, pcb_quantities):
                 # Iterate through the PCB quantities for COGS breakdown
                 for pcb_qty in pcb_quantities:
                     # Initialize a dict for populating COGS for this PCB quantity
-                    pricing_for_pcb_qty = {}
-                    pricing_for_pcb_qty[str(pcb_qty)] = {}
+                    pricing_for_pcb_qty = {"pcb_qty": pcb_qty}
                     # Get the total part count for this PCB quantity
                     part_qty = single_pcb_part_qty * pcb_qty
                     # Set the breakpoint index to start or end of list, or as None,
@@ -245,13 +244,13 @@ def get_prices_for_target_qtys(part_data, single_pcb_part_qty, pcb_quantities):
                         else None
                     )
                     if breakpoint_idx is not None:
-                        pricing_for_pcb_qty[str(pcb_qty)]["break_qty"] = std_pricing[
+                        pricing_for_pcb_qty["break_qty"] = std_pricing[
                             breakpoint_idx
                         ]["BreakQuantity"]
-                        pricing_for_pcb_qty[str(pcb_qty)]["price_per_unit"] = (
+                        pricing_for_pcb_qty["price_per_unit"] = (
                             std_pricing[breakpoint_idx]["UnitPrice"]
                         )
-                        pricing_for_pcb_qty[str(pcb_qty)]["total_price"] = (
+                        pricing_for_pcb_qty["total_price"] = (
                             std_pricing[breakpoint_idx]["UnitPrice"] * part_qty
                         )
                     else:
@@ -259,13 +258,13 @@ def get_prices_for_target_qtys(part_data, single_pcb_part_qty, pcb_quantities):
                         for breakpoint in std_pricing:
                             # If breakpoint index already set, populate
                             if part_qty >= breakpoint["BreakQuantity"]:
-                                pricing_for_pcb_qty[str(pcb_qty)]["break_qty"] = (
+                                pricing_for_pcb_qty["break_qty"] = (
                                     breakpoint["BreakQuantity"]
                                 )
-                                pricing_for_pcb_qty[str(pcb_qty)]["price_per_unit"] = (
+                                pricing_for_pcb_qty["price_per_unit"] = (
                                     breakpoint["UnitPrice"]
                                 )
-                                pricing_for_pcb_qty[str(pcb_qty)]["total_price"] = (
+                                pricing_for_pcb_qty["total_price"] = (
                                     breakpoint["UnitPrice"] * part_qty
                                 )
                     # Append the pricing for this PCB quantity to the list

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -230,10 +230,13 @@ def get_prices_for_target_qtys(part_data, single_pcb_part_qty, pcb_quantities):
                 ]
                 # Iterate through the PCB quantities for COGS breakdown
                 for pcb_qty in pcb_quantities:
-                    # Initialize a dict for populating COGS for this PCB quantity
-                    pricing_for_pcb_qty = {"pcb_qty": pcb_qty}
                     # Get the total part count for this PCB quantity
                     part_qty = single_pcb_part_qty * pcb_qty
+                    # Initialize a dict for populating COGS for this PCB quantity
+                    pricing_for_pcb_qty = {
+                        "pcb_qty": pcb_qty,
+                        "total_part_qty": part_qty
+                    }
                     # Set the breakpoint index to start or end of list, or as None,
                     # depending on the quantity. Set pricing for edge case
                     breakpoint_idx = (

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -232,6 +232,7 @@ def get_prices_for_target_qtys(part_data, single_pcb_part_qty, pcb_quantities):
                 for pcb_qty in pcb_quantities:
                     # Initialize a dict for populating COGS for this PCB quantity
                     pricing_for_pcb_qty = {}
+                    pricing_for_pcb_qty[str(pcb_qty)] = {}
                     # Get the total part count for this PCB quantity
                     part_qty = single_pcb_part_qty * pcb_qty
                     # Set the breakpoint index to start or end of list, or as None,

--- a/report_template/index.html
+++ b/report_template/index.html
@@ -119,6 +119,7 @@
                                 <td>{{ "{:,}".format(pricing['price_per_unit']) }}</td>
                                 <td>{{ "{:,}".format(pricing['total_price']) }}</td>
                             </tr>
+                            {% endfor %}
 						{% endfor %}
                     </tbody>
                 </table>
@@ -127,6 +128,7 @@
         {% endfor %}
     </div>
     {% endif %}
+	{% endfor %}
     <script src="assets/bootstrap/js/bootstrap.min.js"></script>
 </body>
 

--- a/report_template/index.html
+++ b/report_template/index.html
@@ -113,13 +113,11 @@
                     </thead>
                     <tbody>
 						{% for pcb_qty_pricing in package_type['cogs'] %}
-						    {% for qty, pricing in pcb_qty_pricing.items() %}
                             <tr>
-                                <td>{{ "{:,}".format(qty) }}</td>
-                                <td>{{ "{:,}".format(pricing['price_per_unit']) }}</td>
-                                <td>{{ "{:,}".format(pricing['total_price']) }}</td>
+                                <td>{{ "{:,}".format(pcb_qty_pricing['pcb_qty']) }}</td>
+                                <td>{{ "{:,}".format(pcb_qty_pricing['price_per_unit']) }}</td>
+                                <td>{{ "{:,}".format(pcb_qty_pricing['total_price']) }}</td>
                             </tr>
-                            {% endfor %}
 						{% endfor %}
                     </tbody>
                 </table>

--- a/report_template/index.html
+++ b/report_template/index.html
@@ -127,7 +127,6 @@
         {% endfor %}
     </div>
     {% endif %}
-	{% endfor %}
     <script src="assets/bootstrap/js/bootstrap.min.js"></script>
 </body>
 

--- a/report_template/index.html
+++ b/report_template/index.html
@@ -16,13 +16,13 @@
     </div>
 	{% for part in bom %}
     <div style="margin-bottom: 20px;">
-        <div style="width: 48px;margin-left: 30px;color: var(--bs-emphasis-color);background: #d6aa2c;text-align: center;height: 26px;"><span style="font-size: 12px;background: var(--bs-gray-500);height: 0px;">{{ loop.index }}</span></div>
+        <div style="width: 48px;margin-left: 30px;color: var(--bs-emphasis-color);background: #d6aa2c;text-align: center;height: 26px;"><span style="font-size: 12px;background: #d6aa2c;height: 0px;font-weight: bold;">{{ loop.index }}</span></div>
         {% if 'Obsolete' == part.lifecycle_status  %}
-        <div style="margin-left: 30px;margin-right: 30px;border-style: solid;border-color: var(--bs-red);border-radius: 3px;padding-bottom: 0px;">
+        <div style="margin-left: 30px;margin-right: 30px;border-style: solid;border-color: var(--bs-red);border-radius: 3px;padding-bottom: 0px;margin-bottom: 50px;">
         {% elif 'Not For New Designs' == part.lifecycle_status %}
-        <div style="margin-left: 30px;margin-right: 30px;border-style: solid;border-color: var(--bs-red);border-radius: 3px;padding-bottom: 0px;">
+        <div style="margin-left: 30px;margin-right: 30px;border-style: solid;border-color: var(--bs-red);border-radius: 3px;padding-bottom: 0px;margin-bottom: 50px;">
 		{% else %}
-        <div style="margin-left: 30px;margin-right: 30px;border-style: solid;border-color: var(--bs-gray-500);border-radius: 3px;padding-bottom: 0px;">
+        <div style="margin-left: 30px;margin-right: 30px;border-style: solid;border-color: var(--bs-gray-500);border-radius: 3px;padding-bottom: 0px;margin-bottom: 50px;">
 		{% endif %}
     		<div class="row" style="margin-right: 0px;margin-left: 0px;border-color: var(--bs-gray-400);">
                 <div class="col" style="padding-left: initial;"><span style="font-size: 12px;font-weight: bold;padding-left: 13px;">{{ part.categories|join("  >  ") }}</span></div>

--- a/report_template/index.html
+++ b/report_template/index.html
@@ -95,6 +95,38 @@
 			{% endif %}
         </div>
     </div>
+    {% if part.cogs_breakdown is not none %}
+    <div class="row" style="margin-right: 0px;margin-left: 0px;border-color: var(--bs-tertiary-color);border-left-color: rgb(33, 37, 41);margin-bottom: 10px;">
+        <div class="col" style="padding-left: initial;margin-top: 10px;"><span class="border rounded" style="font-size: 10px;padding-left: 10px;background: #0f375f;padding-bottom: 5px;padding-top: 5px;padding-right: 10px;margin-left: 10px;color: rgb(214,170,44);font-weight: bold;">COGS</span></div>
+    </div>
+    <div class="row" style="margin-right: 0px;margin-left: 0px;border-color: var(--bs-gray-400);border-left-color: rgb(33,37,41);">
+        {% for package_type in part.cogs_breakdown %}
+        <div class="col-auto" style="text-align: right;padding-right: 20px;padding-left: 20px;border-style: none;border-color: var(--bs-gray-400);border-right-style: none;border-left-style: none;"><span style="font-size: 12px;font-style: italic;">package_type["package_type"]["Name"]</span>
+            <div class="table-responsive text-end" style="font-size: 12px;line-height: 3px;">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>PCB Qty</th>
+                            <th>Unit Price</th>
+                            <th>Total Price</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+						{% for pcb_qty_pricing in package_type['cogs'] %}
+						    {% for qty, pricing in pcb_qty_pricing.items() %}
+                            <tr>
+                                <td>{{ "{:,}".format(qty) }}</td>
+                                <td>{{ "{:,}".format(pricing['price_per_unit']) }}</td>
+                                <td>{{ "{:,}".format(pricing['total_price']) }}</td>
+                            </tr>
+						{% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
 	{% endfor %}
     <script src="assets/bootstrap/js/bootstrap.min.js"></script>
 </body>

--- a/report_template/index.html
+++ b/report_template/index.html
@@ -16,7 +16,7 @@
     </div>
 	{% for part in bom %}
     <div style="margin-bottom: 20px;">
-        <div style="width: 48px;margin-left: 30px;color: var(--bs-emphasis-color);background: var(--bs-gray-500);text-align: center;height: 26px;"><span style="font-size: 12px;background: var(--bs-gray-500);height: 0px;">{{ loop.index }}</span></div>
+        <div style="width: 48px;margin-left: 30px;color: var(--bs-emphasis-color);background: #d6aa2c;text-align: center;height: 26px;"><span style="font-size: 12px;background: var(--bs-gray-500);height: 0px;">{{ loop.index }}</span></div>
         {% if 'Obsolete' == part.lifecycle_status  %}
         <div style="margin-left: 30px;margin-right: 30px;border-style: solid;border-color: var(--bs-red);border-radius: 3px;padding-bottom: 0px;">
         {% elif 'Not For New Designs' == part.lifecycle_status %}
@@ -31,7 +31,7 @@
                 <div class="col" style="background: var(--bs-secondary-text-emphasis);padding-top: 5px;padding-bottom: 5px;"><span>{{ part.associated_refdes }}</span></div>
             </div>
 			{% if part.mfr_name is not none %}
-            <div class="row g-0">
+            <div class="row g-0" style="border-bottom-style: solid;border-bottom-color: var(--bs-gray-400);">
                 <div class="col-auto text-center" style="padding-right: 20px;padding-left: 20px;border-style: none;border-color: var(--bs-gray-400);"><img src="{{ part.photo_url }}" style="height: 88px;margin-left: 10px;"><a href="{{ part.datasheet_url }}" target="_blank">
                         <p style="text-align: center;font-size: 10px;padding-bottom: 5px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" height="25px"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M0 64C0 28.7 28.7 0 64 0L224 0l0 128c0 17.7 14.3 32 32 32l128 0 0 144-208 0c-35.3 0-64 28.7-64 64l0 144-48 0c-35.3 0-64-28.7-64-64L0 64zm384 64l-128 0L256 0 384 128zM176 352l32 0c30.9 0 56 25.1 56 56s-25.1 56-56 56l-16 0 0 32c0 8.8-7.2 16-16 16s-16-7.2-16-16l0-48 0-80c0-8.8 7.2-16 16-16zm32 80c13.3 0 24-10.7 24-24s-10.7-24-24-24l-16 0 0 48 16 0zm96-80l32 0c26.5 0 48 21.5 48 48l0 64c0 26.5-21.5 48-48 48l-32 0c-8.8 0-16-7.2-16-16l0-128c0-8.8 7.2-16 16-16zm32 128c8.8 0 16-7.2 16-16l0-64c0-8.8-7.2-16-16-16l-16 0 0 96 16 0zm80-112c0-8.8 7.2-16 16-16l48 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-32 0 0 32 32 0c8.8 0 16 7.2 16 16s-7.2 16-16 16l-32 0 0 48c0 8.8-7.2 16-16 16s-16-7.2-16-16l0-64 0-64z" style="fill:var(--bs-secondary-text-emphasis);"/></svg></p>
                     </a></div>
@@ -92,40 +92,42 @@
                     <hr style="width: 50%;margin-bottom: 0px;margin-top: 5px;"><span style="font-size: 12px;font-weight: bold;">HTSUS</span><span style="font-size: 10px;display: block;margin-bottom: 0px;">{{ part.htsus if part.htsus is not none else "-" }}</span>
                 </div>
             </div>
+            {% if part.cogs_breakdown is not none %}
+            <div class="row" style="margin-right: 0px;margin-left: 0px;border-color: var(--bs-tertiary-color);border-left-color: rgb(33, 37, 41);margin-bottom: 10px;">
+                <div class="col" style="padding-left: initial;margin-top: 10px;"><span class="border rounded" style="font-size: 10px;padding-left: 10px;background: #0f375f;padding-bottom: 5px;padding-top: 5px;padding-right: 10px;margin-left: 10px;color: rgb(214,170,44);font-weight: bold;">COGS</span></div>
+            </div>
+            <div class="row" style="margin-right: 0px;margin-left: 0px;border-color: var(--bs-gray-400);border-left-color: rgb(33,37,41);">
+                {% for package_type in part.cogs_breakdown %}
+                <div class="col-auto" style="text-align: right;padding-right: 20px;padding-left: 20px;border-style: none;border-color: var(--bs-gray-400);border-right-style: none;border-left-style: none;"><span style="font-size: 12px;font-style: italic;">{{ package_type["package_type"]["Name"] }}</span>
+                    <div class="table-responsive text-end" style="font-size: 12px;line-height: 3px;">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>PCB Qty</th>
+                                    <th>Total Part Qty</th>
+                                    <th>Unit Price</th>
+                                    <th>Total Price</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+						{% for pcb_qty_pricing in package_type['cogs'] %}
+                                    <tr>
+                                        <td>{{ "{:,}".format(pcb_qty_pricing['pcb_qty']) }}</td>
+                                        <td>{{ "{:,}".format(pcb_qty_pricing['total_part_qty']) }}</td>
+                                        <td>{{ "{:,}".format(pcb_qty_pricing['price_per_unit']) }}</td>
+                                        <td>{{ "{:,.3f}".format(pcb_qty_pricing['total_price']) }}</td>
+                                    </tr>
+						{% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+            {% endif %}
 			{% endif %}
         </div>
     </div>
-    {% if part.cogs_breakdown is not none %}
-    <div class="row" style="margin-right: 0px;margin-left: 0px;border-color: var(--bs-tertiary-color);border-left-color: rgb(33, 37, 41);margin-bottom: 10px;">
-        <div class="col" style="padding-left: initial;margin-top: 10px;"><span class="border rounded" style="font-size: 10px;padding-left: 10px;background: #0f375f;padding-bottom: 5px;padding-top: 5px;padding-right: 10px;margin-left: 10px;color: rgb(214,170,44);font-weight: bold;">COGS</span></div>
-    </div>
-    <div class="row" style="margin-right: 0px;margin-left: 0px;border-color: var(--bs-gray-400);border-left-color: rgb(33,37,41);">
-        {% for package_type in part.cogs_breakdown %}
-        <div class="col-auto" style="text-align: right;padding-right: 20px;padding-left: 20px;border-style: none;border-color: var(--bs-gray-400);border-right-style: none;border-left-style: none;"><span style="font-size: 12px;font-style: italic;">package_type["package_type"]["Name"]</span>
-            <div class="table-responsive text-end" style="font-size: 12px;line-height: 3px;">
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>PCB Qty</th>
-                            <th>Unit Price</th>
-                            <th>Total Price</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-						{% for pcb_qty_pricing in package_type['cogs'] %}
-                            <tr>
-                                <td>{{ "{:,}".format(pcb_qty_pricing['pcb_qty']) }}</td>
-                                <td>{{ "{:,}".format(pcb_qty_pricing['price_per_unit']) }}</td>
-                                <td>{{ "{:,}".format(pcb_qty_pricing['total_price']) }}</td>
-                            </tr>
-						{% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        {% endfor %}
-    </div>
-    {% endif %}
 	{% endfor %}
     <script src="assets/bootstrap/js/bootstrap.min.js"></script>
 </body>


### PR DESCRIPTION
- Added CSV command line input for PCB quantity option
- Calculate price break / unit cost / total cost for each PCB quantity w.r.t. package types and their price breaks from data provider data
- Include COGS breakdown in JSON output of component data
- HTML report includes the COGS breakdown for PCB quantities